### PR TITLE
Add user-customizable theme colors

### DIFF
--- a/app/src/main/kotlin/com/podcapture/MainActivity.kt
+++ b/app/src/main/kotlin/com/podcapture/MainActivity.kt
@@ -7,18 +7,43 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import com.podcapture.data.settings.SettingsDataStore
 import com.podcapture.ui.navigation.PodCaptureNavHost
 import com.podcapture.ui.theme.PodCaptureTheme
+import com.podcapture.ui.theme.ThemeColors
+import com.podcapture.ui.theme.parseHexColor
+import kotlinx.coroutines.flow.combine
+import org.koin.android.ext.android.inject
 
 class MainActivity : ComponentActivity() {
+
+    private val settingsDataStore: SettingsDataStore by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
         setContent {
-            PodCaptureTheme {
+            val themeColorsFlow = remember {
+                combine(
+                    settingsDataStore.themeBackgroundColor,
+                    settingsDataStore.themeAccent1Color,
+                    settingsDataStore.themeAccent2Color
+                ) { background, accent1, accent2 ->
+                    ThemeColors(
+                        backgroundColor = parseHexColor(background) ?: ThemeColors.Default.backgroundColor,
+                        accent1Color = parseHexColor(accent1) ?: ThemeColors.Default.accent1Color,
+                        accent2Color = parseHexColor(accent2) ?: ThemeColors.Default.accent2Color
+                    )
+                }
+            }
+            val themeColors by themeColorsFlow.collectAsState(initial = ThemeColors.Default)
+
+            PodCaptureTheme(themeColors = themeColors) {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background

--- a/app/src/main/kotlin/com/podcapture/data/settings/SettingsDataStore.kt
+++ b/app/src/main/kotlin/com/podcapture/data/settings/SettingsDataStore.kt
@@ -23,9 +23,15 @@ class SettingsDataStore(private val context: Context) {
         private val API_CALL_COUNT = intPreferencesKey("api_call_count")
         private val API_CALL_COUNT_DATE = stringPreferencesKey("api_call_count_date")
         private val LATEST_EPISODES_CACHE_DATE = stringPreferencesKey("latest_episodes_cache_date")
+        private val THEME_BACKGROUND_COLOR = stringPreferencesKey("theme_background_color")
+        private val THEME_ACCENT1_COLOR = stringPreferencesKey("theme_accent1_color")
+        private val THEME_ACCENT2_COLOR = stringPreferencesKey("theme_accent2_color")
         const val DEFAULT_CAPTURE_WINDOW = 30
         const val DEFAULT_SKIP_INTERVAL = 10
         const val DEFAULT_OBSIDIAN_TAGS = "inbox/, resources/references/podcasts"
+        const val DEFAULT_THEME_BACKGROUND = "#13293D"
+        const val DEFAULT_THEME_ACCENT1 = "#2A628F"
+        const val DEFAULT_THEME_ACCENT2 = "#3E92CC"
     }
 
     val captureWindowSeconds: Flow<Int> = context.dataStore.data
@@ -63,6 +69,21 @@ class SettingsDataStore(private val context: Context) {
     val apiCallCountDate: Flow<String> = context.dataStore.data
         .map { preferences ->
             preferences[API_CALL_COUNT_DATE] ?: ""
+        }
+
+    val themeBackgroundColor: Flow<String> = context.dataStore.data
+        .map { preferences ->
+            preferences[THEME_BACKGROUND_COLOR] ?: DEFAULT_THEME_BACKGROUND
+        }
+
+    val themeAccent1Color: Flow<String> = context.dataStore.data
+        .map { preferences ->
+            preferences[THEME_ACCENT1_COLOR] ?: DEFAULT_THEME_ACCENT1
+        }
+
+    val themeAccent2Color: Flow<String> = context.dataStore.data
+        .map { preferences ->
+            preferences[THEME_ACCENT2_COLOR] ?: DEFAULT_THEME_ACCENT2
         }
 
     suspend fun incrementApiCallCount() {
@@ -135,5 +156,33 @@ class SettingsDataStore(private val context: Context) {
     fun getTodayDate(): String {
         return java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.US)
             .format(java.util.Date())
+    }
+
+    // ============ Theme Colors ============
+
+    suspend fun setThemeBackgroundColor(color: String) {
+        context.dataStore.edit { preferences ->
+            preferences[THEME_BACKGROUND_COLOR] = color
+        }
+    }
+
+    suspend fun setThemeAccent1Color(color: String) {
+        context.dataStore.edit { preferences ->
+            preferences[THEME_ACCENT1_COLOR] = color
+        }
+    }
+
+    suspend fun setThemeAccent2Color(color: String) {
+        context.dataStore.edit { preferences ->
+            preferences[THEME_ACCENT2_COLOR] = color
+        }
+    }
+
+    suspend fun resetThemeColors() {
+        context.dataStore.edit { preferences ->
+            preferences[THEME_BACKGROUND_COLOR] = DEFAULT_THEME_BACKGROUND
+            preferences[THEME_ACCENT1_COLOR] = DEFAULT_THEME_ACCENT1
+            preferences[THEME_ACCENT2_COLOR] = DEFAULT_THEME_ACCENT2
+        }
     }
 }

--- a/app/src/main/kotlin/com/podcapture/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/podcapture/ui/settings/SettingsViewModel.kt
@@ -15,6 +15,9 @@ data class SettingsUiState(
     val obsidianVaultDisplayName: String = "",
     val obsidianDefaultTags: String = "inbox/, resources/references/podcasts",
     val apiCallCount: Int = 0,
+    val themeBackgroundColor: String = "#13293D",
+    val themeAccent1Color: String = "#2A628F",
+    val themeAccent2Color: String = "#3E92CC",
     val isLoading: Boolean = true
 )
 
@@ -66,6 +69,27 @@ class SettingsViewModel(
                 )
             }
         }
+        viewModelScope.launch {
+            settingsDataStore.themeBackgroundColor.collect { color ->
+                _uiState.value = _uiState.value.copy(
+                    themeBackgroundColor = color
+                )
+            }
+        }
+        viewModelScope.launch {
+            settingsDataStore.themeAccent1Color.collect { color ->
+                _uiState.value = _uiState.value.copy(
+                    themeAccent1Color = color
+                )
+            }
+        }
+        viewModelScope.launch {
+            settingsDataStore.themeAccent2Color.collect { color ->
+                _uiState.value = _uiState.value.copy(
+                    themeAccent2Color = color
+                )
+            }
+        }
     }
 
     fun setCaptureWindowSeconds(seconds: Int) {
@@ -89,6 +113,30 @@ class SettingsViewModel(
     fun setObsidianDefaultTags(tags: String) {
         viewModelScope.launch {
             settingsDataStore.setObsidianDefaultTags(tags)
+        }
+    }
+
+    fun setThemeBackgroundColor(color: String) {
+        viewModelScope.launch {
+            settingsDataStore.setThemeBackgroundColor(color)
+        }
+    }
+
+    fun setThemeAccent1Color(color: String) {
+        viewModelScope.launch {
+            settingsDataStore.setThemeAccent1Color(color)
+        }
+    }
+
+    fun setThemeAccent2Color(color: String) {
+        viewModelScope.launch {
+            settingsDataStore.setThemeAccent2Color(color)
+        }
+    }
+
+    fun resetThemeColors() {
+        viewModelScope.launch {
+            settingsDataStore.resetThemeColors()
         }
     }
 }

--- a/app/src/main/kotlin/com/podcapture/ui/theme/Color.kt
+++ b/app/src/main/kotlin/com/podcapture/ui/theme/Color.kt
@@ -1,25 +1,104 @@
 package com.podcapture.ui.theme
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 
-// Primary - Deep Purple/Indigo tones
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+// ============ Color Utility Functions ============
 
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+fun parseHexColor(hex: String): Color? {
+    val cleanHex = hex.removePrefix("#").uppercase()
+    if (cleanHex.length != 6) return null
+    return try {
+        val colorInt = cleanHex.toLong(16)
+        Color(
+            red = ((colorInt shr 16) and 0xFF) / 255f,
+            green = ((colorInt shr 8) and 0xFF) / 255f,
+            blue = (colorInt and 0xFF) / 255f
+        )
+    } catch (e: NumberFormatException) {
+        null
+    }
+}
 
-// App-specific colors
-val PodCapturePrimary = Color(0xFF6366F1)        // Indigo
-val PodCapturePrimaryDark = Color(0xFF4F46E5)
-val PodCaptureSecondary = Color(0xFF8B5CF6)      // Violet
-val PodCaptureAccent = Color(0xFF06B6D4)         // Cyan - for capture button
+fun isValidHexColor(hex: String): Boolean {
+    val cleanHex = hex.removePrefix("#").uppercase()
+    if (cleanHex.length != 6) return false
+    return cleanHex.all { it in '0'..'9' || it in 'A'..'F' }
+}
 
-val SurfaceDark = Color(0xFF1E1E2E)
-val SurfaceLight = Color(0xFFF8FAFC)
+fun Color.lighten(factor: Float): Color = Color(
+    red = (red + (1f - red) * factor).coerceIn(0f, 1f),
+    green = (green + (1f - green) * factor).coerceIn(0f, 1f),
+    blue = (blue + (1f - blue) * factor).coerceIn(0f, 1f),
+    alpha = alpha
+)
 
-val CaptureMarkerColor = Color(0xFFF59E0B)       // Amber for timeline markers
-val WaveformColor = Color(0xFF94A3B8)            // Slate gray for waveform
-val WaveformPlayedColor = Color(0xFF6366F1)      // Indigo for played portion
+fun Color.darken(factor: Float): Color = Color(
+    red = (red * (1f - factor)).coerceIn(0f, 1f),
+    green = (green * (1f - factor)).coerceIn(0f, 1f),
+    blue = (blue * (1f - factor)).coerceIn(0f, 1f),
+    alpha = alpha
+)
+
+fun Color.contrastingOnColor(): Color {
+    return if (luminance() > 0.5f) {
+        Color(0xFF13293D) // Dark text for light backgrounds
+    } else {
+        Color(0xFFE8F1F8) // Light text for dark backgrounds
+    }
+}
+
+// ============ Core Brand Colors ============
+// Deep navy background with ocean blue accents
+
+val NavyDark = Color(0xFF13293D)           // Primary background
+val NavyDeep = Color(0xFF0D1B2A)           // Deeper navy for contrast
+val NavyMedium = Color(0xFF1B3A52)         // Elevated surfaces
+val NavyLight = Color(0xFF234B67)          // Lighter navy accent
+
+val OceanBlue = Color(0xFF3E92CC)          // Primary accent - bright blue
+val OceanBlueMuted = Color(0xFF2A628F)     // Muted ocean blue
+val OceanBlueDark = Color(0xFF1E4A6B)      // Dark ocean blue for containers
+
+val SteelBlue = Color(0xFF2A628F)          // Secondary accent - medium blue
+val SteelBlueMuted = Color(0xFF1F4A6D)     // Muted steel blue
+val SteelBlueDark = Color(0xFF16354D)      // Dark steel blue
+
+// ============ Functional Colors ============
+val Coral = Color(0xFFFF8A7A)              // Tertiary - capture button, fun accent
+val CoralMuted = Color(0xFFE07868)         // Muted coral
+val CoralDark = Color(0xFFB85A4A)          // Dark coral
+
+val Mint = Color(0xFF7EDEB8)               // Success states
+val Amber = Color(0xFFFFB74D)              // Warnings, markers
+val Rose = Color(0xFFFF6B8A)               // Error states
+
+// ============ Surface Colors - Dark Theme ============
+val SurfaceDark = Color(0xFF13293D)        // Main background
+val SurfaceContainerDark = Color(0xFF0D1B2A)  // Lower surfaces
+val SurfaceContainerHighDark = Color(0xFF1B3A52) // Cards, elevated
+val SurfaceVariantDark = Color(0xFF234B67) // Variant surfaces
+
+// ============ Surface Colors - Light Theme ============
+val SurfaceLight = Color(0xFFF5F8FA)       // Main background
+val SurfaceContainerLight = Color(0xFFFFFFFF)  // Cards
+val SurfaceContainerHighLight = Color(0xFFE8F0F5) // Elevated
+val SurfaceVariantLight = Color(0xFFDCE8F0) // Variant surfaces
+
+// ============ Text Colors ============
+val OnDarkSurface = Color(0xFFE8F1F8)      // Primary text on dark
+val OnDarkSurfaceVariant = Color(0xFFA8C4D8) // Secondary text on dark
+val OnLightSurface = Color(0xFF13293D)     // Primary text on light
+val OnLightSurfaceVariant = Color(0xFF4A6B82) // Secondary text on light
+
+// ============ Outline Colors ============
+val OutlineDark = Color(0xFF4A6B82)        // Borders on dark
+val OutlineVariantDark = Color(0xFF2A4A60) // Subtle borders on dark
+val OutlineLight = Color(0xFFA8C4D8)       // Borders on light
+val OutlineVariantLight = Color(0xFFC8DCE8) // Subtle borders on light
+
+// ============ Waveform & Player Colors ============
+val WaveformUnplayed = Color(0xFF4A6B82)   // Unplayed waveform bars
+val WaveformPlayed = Color(0xFF3E92CC)     // Played waveform bars (ocean blue)
+val PlayheadColor = Color(0xFFFF8A7A)      // Playhead indicator (coral)
+val CaptureMarkerColor = Color(0xFFFFB74D) // Capture point markers (amber)

--- a/app/src/main/kotlin/com/podcapture/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/podcapture/ui/theme/Theme.kt
@@ -1,44 +1,275 @@
 package com.podcapture.ui.theme
 
-import android.os.Build
+import android.app.Activity
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+
+@Immutable
+data class ThemeColors(
+    val backgroundColor: Color,
+    val accent1Color: Color,
+    val accent2Color: Color
+) {
+    companion object {
+        val Default = ThemeColors(
+            backgroundColor = Color(0xFF13293D),
+            accent1Color = Color(0xFF2A628F),
+            accent2Color = Color(0xFF3E92CC)
+        )
+    }
+}
+
+private fun generateDarkColorScheme(colors: ThemeColors): ColorScheme {
+    val background = colors.backgroundColor
+    val accent1 = colors.accent1Color
+    val accent2 = colors.accent2Color
+    val onSurface = background.contrastingOnColor()
+    val onSurfaceVariant = onSurface.copy(alpha = 0.7f)
+
+    return darkColorScheme(
+        // Primary - accent2 (brighter, for buttons/highlights)
+        primary = accent2,
+        onPrimary = background.darken(0.3f),
+        primaryContainer = accent2.darken(0.4f),
+        onPrimaryContainer = accent2,
+
+        // Secondary - accent1 (muted)
+        secondary = accent1,
+        onSecondary = background.darken(0.3f),
+        secondaryContainer = accent1.darken(0.4f),
+        onSecondaryContainer = accent2,
+
+        // Tertiary - Keep Coral for capture actions
+        tertiary = Coral,
+        onTertiary = background.darken(0.3f),
+        tertiaryContainer = CoralMuted,
+        onTertiaryContainer = background.darken(0.3f),
+
+        // Background & Surface
+        background = background,
+        onBackground = onSurface,
+        surface = background,
+        onSurface = onSurface,
+        surfaceVariant = background.lighten(0.1f),
+        onSurfaceVariant = onSurfaceVariant,
+        surfaceContainerLowest = background.darken(0.3f),
+        surfaceContainerLow = background.darken(0.3f),
+        surfaceContainer = background,
+        surfaceContainerHigh = background.lighten(0.1f),
+        surfaceContainerHighest = background.lighten(0.15f),
+
+        // Outline
+        outline = accent1.lighten(0.2f),
+        outlineVariant = accent1.darken(0.2f),
+
+        // Inverse (for snackbars, tooltips)
+        inverseSurface = SurfaceLight,
+        inverseOnSurface = OnLightSurface,
+        inversePrimary = accent1,
+
+        // Error
+        error = Rose,
+        onError = background.darken(0.3f),
+        errorContainer = Color(0xFF5C2030),
+        onErrorContainer = Rose,
+
+        // Scrim
+        scrim = Color(0xFF000000)
+    )
+}
+
+private fun generateLightColorScheme(colors: ThemeColors): ColorScheme {
+    val background = colors.backgroundColor
+    val accent1 = colors.accent1Color
+    val accent2 = colors.accent2Color
+
+    return lightColorScheme(
+        // Primary - accent1 (darker for light theme)
+        primary = accent1,
+        onPrimary = Color.White,
+        primaryContainer = accent2,
+        onPrimaryContainer = background.darken(0.3f),
+
+        // Secondary - accent2
+        secondary = accent2.darken(0.2f),
+        onSecondary = Color.White,
+        secondaryContainer = accent2,
+        onSecondaryContainer = background.darken(0.3f),
+
+        // Tertiary - Coral
+        tertiary = CoralDark,
+        onTertiary = Color.White,
+        tertiaryContainer = Coral,
+        onTertiaryContainer = background.darken(0.3f),
+
+        // Background & Surface
+        background = SurfaceLight,
+        onBackground = OnLightSurface,
+        surface = SurfaceLight,
+        onSurface = OnLightSurface,
+        surfaceVariant = SurfaceVariantLight,
+        onSurfaceVariant = OnLightSurfaceVariant,
+        surfaceContainerLowest = Color.White,
+        surfaceContainerLow = Color.White,
+        surfaceContainer = SurfaceContainerLight,
+        surfaceContainerHigh = SurfaceContainerHighLight,
+        surfaceContainerHighest = SurfaceVariantLight,
+
+        // Outline
+        outline = OutlineLight,
+        outlineVariant = OutlineVariantLight,
+
+        // Inverse (for snackbars, tooltips)
+        inverseSurface = background,
+        inverseOnSurface = OnDarkSurface,
+        inversePrimary = accent2,
+
+        // Error
+        error = Rose,
+        onError = Color.White,
+        errorContainer = Color(0xFFFFDAD6),
+        onErrorContainer = Color(0xFF5C1A1A),
+
+        // Scrim
+        scrim = Color(0xFF000000)
+    )
+}
 
 private val DarkColorScheme = darkColorScheme(
-    primary = PodCapturePrimary,
-    secondary = PodCaptureSecondary,
-    tertiary = PodCaptureAccent,
-    background = SurfaceDark,
-    surface = SurfaceDark,
+    // Primary - Ocean Blue accent
+    primary = OceanBlue,
+    onPrimary = NavyDeep,
+    primaryContainer = OceanBlueDark,
+    onPrimaryContainer = OceanBlue,
+
+    // Secondary - Steel Blue accent
+    secondary = SteelBlue,
+    onSecondary = NavyDeep,
+    secondaryContainer = SteelBlueDark,
+    onSecondaryContainer = OceanBlue,
+
+    // Tertiary - Coral for capture/fun actions
+    tertiary = Coral,
+    onTertiary = NavyDeep,
+    tertiaryContainer = CoralMuted,
+    onTertiaryContainer = NavyDeep,
+
+    // Background & Surface
+    background = NavyDark,
+    onBackground = OnDarkSurface,
+    surface = NavyDark,
+    onSurface = OnDarkSurface,
+    surfaceVariant = NavyMedium,
+    onSurfaceVariant = OnDarkSurfaceVariant,
+    surfaceContainerLowest = NavyDeep,
+    surfaceContainerLow = NavyDeep,
+    surfaceContainer = NavyDark,
+    surfaceContainerHigh = NavyMedium,
+    surfaceContainerHighest = NavyLight,
+
+    // Outline
+    outline = OutlineDark,
+    outlineVariant = OutlineVariantDark,
+
+    // Inverse (for snackbars, tooltips)
+    inverseSurface = SurfaceLight,
+    inverseOnSurface = OnLightSurface,
+    inversePrimary = SteelBlue,
+
+    // Error
+    error = Rose,
+    onError = NavyDeep,
+    errorContainer = Color(0xFF5C2030),
+    onErrorContainer = Rose,
+
+    // Scrim
+    scrim = Color(0xFF000000)
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = PodCapturePrimaryDark,
-    secondary = PodCaptureSecondary,
-    tertiary = PodCaptureAccent,
+    // Primary - Steel Blue (darker for light theme)
+    primary = SteelBlue,
+    onPrimary = Color.White,
+    primaryContainer = OceanBlue,
+    onPrimaryContainer = NavyDeep,
+
+    // Secondary - Ocean Blue
+    secondary = OceanBlueMuted,
+    onSecondary = Color.White,
+    secondaryContainer = OceanBlue,
+    onSecondaryContainer = NavyDeep,
+
+    // Tertiary - Coral
+    tertiary = CoralDark,
+    onTertiary = Color.White,
+    tertiaryContainer = Coral,
+    onTertiaryContainer = NavyDeep,
+
+    // Background & Surface
     background = SurfaceLight,
+    onBackground = OnLightSurface,
     surface = SurfaceLight,
+    onSurface = OnLightSurface,
+    surfaceVariant = SurfaceVariantLight,
+    onSurfaceVariant = OnLightSurfaceVariant,
+    surfaceContainerLowest = Color.White,
+    surfaceContainerLow = Color.White,
+    surfaceContainer = SurfaceContainerLight,
+    surfaceContainerHigh = SurfaceContainerHighLight,
+    surfaceContainerHighest = SurfaceVariantLight,
+
+    // Outline
+    outline = OutlineLight,
+    outlineVariant = OutlineVariantLight,
+
+    // Inverse (for snackbars, tooltips)
+    inverseSurface = NavyDark,
+    inverseOnSurface = OnDarkSurface,
+    inversePrimary = OceanBlue,
+
+    // Error
+    error = Rose,
+    onError = Color.White,
+    errorContainer = Color(0xFFFFDAD6),
+    onErrorContainer = Color(0xFF5C1A1A),
+
+    // Scrim
+    scrim = Color(0xFF000000)
 )
 
 @Composable
 fun PodCaptureTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    dynamicColor: Boolean = true,
+    dynamicColor: Boolean = false, // Disabled to use our custom colors
+    themeColors: ThemeColors = ThemeColors.Default,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+    val colorScheme = if (darkTheme) {
+        generateDarkColorScheme(themeColors)
+    } else {
+        generateLightColorScheme(themeColors)
+    }
+
+    // Set status bar and navigation bar colors
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            window.statusBarColor = Color.Transparent.toArgb()
+            window.navigationBarColor = Color.Transparent.toArgb()
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
+            WindowCompat.getInsetsController(window, view).isAppearanceLightNavigationBars = !darkTheme
         }
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
     }
 
     MaterialTheme(

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Brand Colors -->
+    <color name="navy_dark">#FF13293D</color>
+    <color name="navy_deep">#FF0D1B2A</color>
+    <color name="ocean_blue">#FF3E92CC</color>
+    <color name="steel_blue">#FF2A628F</color>
+    <color name="coral">#FFFF8A7A</color>
+
+    <!-- Legacy colors (kept for compatibility) -->
     <color name="purple_200">#FFBB86FC</color>
     <color name="purple_500">#FF6200EE</color>
     <color name="purple_700">#FF3700B3</color>


### PR DESCRIPTION
## Summary
- Add Settings UI for customizing app color scheme with 3 hex color inputs (background, accent 1, accent 2)
- Colors persist in DataStore and update the theme live across the entire app
- Add "Reset to Default Colors" button to restore defaults
- Add color utility functions for parsing hex, lightening/darkening, and contrast detection

## Test plan
- [x] Open Settings and scroll to Theme section
- [x] Enter valid hex colors and verify preview boxes update
- [x] Verify theme updates immediately across the app
- [x] Kill and reopen app - colors should persist
- [x] Enter invalid hex (e.g., "xyz") - verify error state shown, app doesn't crash
- [x] Tap "Reset to Default Colors" - verify defaults restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)