### PR TITLE
Add latest podcast episodes section to search screen

### DIFF
--- a/app/src/main/kotlin/com/podcapture/data/db/PodcastDao.kt
+++ b/app/src/main/kotlin/com/podcapture/data/db/PodcastDao.kt
@@ -135,6 +135,19 @@ interface PodcastDao {
     @Query("DELETE FROM episode_playback_history WHERE episodeId = :episodeId")
     suspend fun deletePlaybackHistory(episodeId: Long)
 
+    // ============ Latest Episodes (Across All Bookmarked Podcasts) ============
+
+    @Query("""
+        SELECT ce.* FROM cached_episodes ce
+        INNER JOIN bookmarked_podcasts bp ON ce.podcastId = bp.id
+        WHERE ce.publishedDate >= :sinceTimestamp
+        ORDER BY ce.publishedDate DESC
+    """)
+    suspend fun getRecentEpisodesFromBookmarkedPodcasts(sinceTimestamp: Long): List<CachedEpisode>
+
+    @Query("SELECT * FROM bookmarked_podcasts WHERE id IN (:podcastIds)")
+    suspend fun getBookmarkedPodcastsByIds(podcastIds: List<Long>): List<BookmarkedPodcast>
+
     // ============ Combined Queries ============
 
     @Transaction

--- a/app/src/main/kotlin/com/podcapture/data/model/CachedEpisode.kt
+++ b/app/src/main/kotlin/com/podcapture/data/model/CachedEpisode.kt
@@ -61,3 +61,12 @@ enum class EpisodeDownloadState {
     Downloaded,
     Error
 }
+
+/**
+ * Episode with podcast info for display in latest episodes list.
+ */
+data class LatestEpisode(
+    val episode: CachedEpisode,
+    val podcastTitle: String,
+    val podcastArtworkUrl: String
+)

--- a/app/src/main/kotlin/com/podcapture/data/settings/SettingsDataStore.kt
+++ b/app/src/main/kotlin/com/podcapture/data/settings/SettingsDataStore.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
@@ -21,6 +22,7 @@ class SettingsDataStore(private val context: Context) {
         private val OBSIDIAN_DEFAULT_TAGS = stringPreferencesKey("obsidian_default_tags")
         private val API_CALL_COUNT = intPreferencesKey("api_call_count")
         private val API_CALL_COUNT_DATE = stringPreferencesKey("api_call_count_date")
+        private val LATEST_EPISODES_CACHE_DATE = stringPreferencesKey("latest_episodes_cache_date")
         const val DEFAULT_CAPTURE_WINDOW = 30
         const val DEFAULT_SKIP_INTERVAL = 10
         const val DEFAULT_OBSIDIAN_TAGS = "inbox/, resources/references/podcasts"
@@ -109,5 +111,29 @@ class SettingsDataStore(private val context: Context) {
         context.dataStore.edit { preferences ->
             preferences[OBSIDIAN_DEFAULT_TAGS] = tags
         }
+    }
+
+    // ============ Latest Episodes Cache ============
+
+    val latestEpisodesCacheDate: Flow<String> = context.dataStore.data
+        .map { preferences ->
+            preferences[LATEST_EPISODES_CACHE_DATE] ?: ""
+        }
+
+    suspend fun getLatestEpisodesCacheDate(): String {
+        return context.dataStore.data.map { preferences ->
+            preferences[LATEST_EPISODES_CACHE_DATE] ?: ""
+        }.first()
+    }
+
+    suspend fun setLatestEpisodesCacheDate(date: String) {
+        context.dataStore.edit { preferences ->
+            preferences[LATEST_EPISODES_CACHE_DATE] = date
+        }
+    }
+
+    fun getTodayDate(): String {
+        return java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.US)
+            .format(java.util.Date())
     }
 }

--- a/app/src/main/kotlin/com/podcapture/di/AppModule.kt
+++ b/app/src/main/kotlin/com/podcapture/di/AppModule.kt
@@ -67,7 +67,7 @@ val appModule = module {
     viewModel { params -> PlayerViewModel(params.get(), get(), get(), get(), get(), get()) }
     viewModel { SettingsViewModel(get()) }
     viewModel { params -> ViewerViewModel(params.get(), androidContext(), get(), get(), get(), get(), get(), get()) }
-    viewModel { PodcastSearchViewModel(get()) }
+    viewModel { PodcastSearchViewModel(get(), get()) }
     viewModel { params -> PodcastDetailViewModel(params.get(), get(), get(), get(), get()) }
     viewModel { params -> EpisodePlayerViewModel(params.get(), params.get(), get(), get(), get(), get(), get(), get(), get()) }
 }

--- a/app/src/main/kotlin/com/podcapture/ui/navigation/PodCaptureNavHost.kt
+++ b/app/src/main/kotlin/com/podcapture/ui/navigation/PodCaptureNavHost.kt
@@ -166,6 +166,9 @@ fun PodCaptureNavHost(
                     onNavigateBack = { navController.popBackStack() },
                     onPodcastSelected = { podcastId ->
                         navController.navigate(NavRoute.PodcastDetail(podcastId))
+                    },
+                    onEpisodeSelected = { episodeId, podcastId ->
+                        navController.navigate(NavRoute.EpisodePlayer(episodeId, podcastId))
                     }
                 )
             }


### PR DESCRIPTION
## Summary
- Add a "Latest Episodes" section to the podcast search screen showing recent episodes from subscribed podcasts
- Implement caching for episodes with repository layer support
- Add database queries and settings for managing latest episodes display

## Test plan
- [x] Verify latest episodes appear on the search screen
- [x] Confirm episodes update when new podcasts are subscribed
- [x] Test caching behavior and data persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)