### PR TITLE
Add delete capture feature with confirmation dialog

### DIFF
--- a/app/src/main/kotlin/com/podcapture/data/repository/CaptureRepository.kt
+++ b/app/src/main/kotlin/com/podcapture/data/repository/CaptureRepository.kt
@@ -109,6 +109,14 @@ class CaptureRepository(
         captureDao.updateNotes(captureId, notes)
     }
 
+    /**
+     * Deletes a capture without updating markdown file.
+     * Used when AudioFile is not available (e.g., podcast episodes).
+     */
+    suspend fun deleteCaptureSimple(captureId: String) {
+        captureDao.deleteCapture(captureId)
+    }
+
     fun getMarkdownContent(audioFile: AudioFile): String? =
         markdownManager.getMarkdownContent(audioFile)
 

--- a/app/src/main/kotlin/com/podcapture/ui/viewer/ViewerScreen.kt
+++ b/app/src/main/kotlin/com/podcapture/ui/viewer/ViewerScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -232,6 +233,9 @@ fun ViewerScreen(
                         },
                         onTagClick = {
                             viewModel.onOpenTagDialog(captureWithTags.capture.id)
+                        },
+                        onDeleteClick = {
+                            viewModel.onRequestDeleteCapture(captureWithTags.capture)
                         }
                     )
                 }
@@ -260,6 +264,27 @@ fun ViewerScreen(
                 onToggleTag = viewModel::onToggleTagForCapture,
                 onDeleteTag = viewModel::onDeleteTag,
                 onDismiss = viewModel::onCloseTagDialog
+            )
+        }
+
+        // Delete capture confirmation dialog
+        if (uiState.showDeleteConfirmDialog && uiState.captureToDelete != null) {
+            AlertDialog(
+                onDismissRequest = { viewModel.onDismissDeleteDialog() },
+                title = { Text("Delete Capture") },
+                text = {
+                    Text("Are you sure you want to delete this capture? This action cannot be undone.")
+                },
+                confirmButton = {
+                    TextButton(onClick = { viewModel.onConfirmDeleteCapture() }) {
+                        Text("Delete", color = MaterialTheme.colorScheme.error)
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { viewModel.onDismissDeleteDialog() }) {
+                        Text("Cancel")
+                    }
+                }
             )
         }
 
@@ -316,6 +341,7 @@ private fun CaptureCard(
     onClick: () -> Unit,
     onEditNotes: () -> Unit,
     onTagClick: () -> Unit,
+    onDeleteClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Card(
@@ -364,6 +390,18 @@ private fun CaptureCard(
                             contentDescription = if (capture.notes.isNullOrBlank()) "Add notes" else "Edit notes",
                             modifier = Modifier.size(18.dp),
                             tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    // Delete button
+                    IconButton(
+                        onClick = { onDeleteClick() },
+                        modifier = Modifier.size(32.dp)
+                    ) {
+                        Icon(
+                            Icons.Outlined.Delete,
+                            contentDescription = "Delete capture",
+                            modifier = Modifier.size(18.dp),
+                            tint = MaterialTheme.colorScheme.error
                         )
                     }
                     Spacer(modifier = Modifier.width(4.dp))

--- a/app/src/main/kotlin/com/podcapture/ui/viewer/ViewerViewModel.kt
+++ b/app/src/main/kotlin/com/podcapture/ui/viewer/ViewerViewModel.kt
@@ -48,7 +48,10 @@ data class ViewerUiState(
     val obsidianPreview: String = "",
     val obsidianVaultUri: String = "",
     val obsidianDefaultTags: String = "inbox/, resources/references/podcasts",
-    val obsidianExportResult: ObsidianExportResult? = null
+    val obsidianExportResult: ObsidianExportResult? = null,
+    // Delete capture state
+    val showDeleteConfirmDialog: Boolean = false,
+    val captureToDelete: Capture? = null
 ) {
     // Helper property for backwards compatibility
     val captures: List<Capture> get() = capturesWithTags.map { it.capture }
@@ -416,5 +419,36 @@ class ViewerViewModel(
 
     fun clearExportResult() {
         _uiState.value = _uiState.value.copy(obsidianExportResult = null)
+    }
+
+    // Delete capture
+    fun onRequestDeleteCapture(capture: Capture) {
+        _uiState.value = _uiState.value.copy(
+            showDeleteConfirmDialog = true,
+            captureToDelete = capture
+        )
+    }
+
+    fun onConfirmDeleteCapture() {
+        val capture = _uiState.value.captureToDelete ?: return
+        viewModelScope.launch {
+            val audioFile = _uiState.value.audioFile
+            if (audioFile != null) {
+                captureRepository.deleteCapture(capture.id, audioFile)
+            } else {
+                captureRepository.deleteCaptureSimple(capture.id)
+            }
+            _uiState.value = _uiState.value.copy(
+                showDeleteConfirmDialog = false,
+                captureToDelete = null
+            )
+        }
+    }
+
+    fun onDismissDeleteDialog() {
+        _uiState.value = _uiState.value.copy(
+            showDeleteConfirmDialog = false,
+            captureToDelete = null
+        )
     }
 }


### PR DESCRIPTION
- Add deleteCaptureSimple() to CaptureRepository for podcast episodes
- Add delete state and handlers to ViewerViewModel
- Add delete icon button (red trash) to CaptureCard
- Add confirmation dialog before deletion