### PR TITLE
Fix crash when downloading episode from unbookmarked podcast

### DIFF
--- a/app/src/main/kotlin/com/podcapture/ui/search/PodcastDetailViewModel.kt
+++ b/app/src/main/kotlin/com/podcapture/ui/search/PodcastDetailViewModel.kt
@@ -321,13 +321,17 @@ class PodcastDetailViewModel(
     /**
      * Start downloading an episode using the background DownloadManager.
      * Downloads continue even if the user leaves this screen.
+     * If the podcast is not bookmarked, it will be auto-bookmarked to satisfy
+     * the database foreign key constraint.
      */
     fun onDownloadEpisode(episodeId: Long) {
         val episode = _uiState.value.episodes.find { it.episode.id == episodeId }?.episode ?: return
-        val podcastTitle = _uiState.value.podcast?.title ?: ""
+        val podcast = _uiState.value.podcast
+        val podcastTitle = podcast?.title ?: ""
 
         // Use DownloadManager for background downloads
-        downloadManager.downloadEpisode(episode, podcastTitle)
+        // Pass the podcast so it can be auto-bookmarked if needed
+        downloadManager.downloadEpisode(episode, podcastTitle, podcast)
     }
 
     // Tag management


### PR DESCRIPTION
## Summary
- Fixed crash caused by foreign key constraint violation when downloading an episode from a non-bookmarked podcast
- Auto-bookmarks the podcast before caching the episode to ensure the `CachedEpisode` FK to `BookmarkedPodcast` is satisfied
- Updated `DownloadManager` to accept optional `Podcast` parameter and check bookmark status before caching

## Test plan
- [x] Open a podcast that is NOT bookmarked
- [x] Tap download on an episode
- [x] Verify the download completes without crashing
- [x] Verify the podcast is now bookmarked

🤖 Generated with [Claude Code](https://claude.com/claude-code)