### PR TITLE
feat: store episode playback timestamp and track finished state

### DIFF
--- a/app/src/main/kotlin/com/podcapture/data/db/PodCaptureDatabase.kt
+++ b/app/src/main/kotlin/com/podcapture/data/db/PodCaptureDatabase.kt
@@ -28,7 +28,7 @@ import com.podcapture.data.model.Tag
         EpisodePlaybackHistory::class,
         PodcastTag::class
     ],
-    version = 9,
+    version = 10,
     exportSchema = true
 )
 abstract class PodCaptureDatabase : RoomDatabase() {
@@ -239,6 +239,15 @@ abstract class PodCaptureDatabase : RoomDatabase() {
             }
         }
 
+        // Migration from version 9 to 10: Add isFinished column to episode_playback_history
+        private val MIGRATION_9_10 = object : Migration(9, 10) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE episode_playback_history ADD COLUMN isFinished INTEGER NOT NULL DEFAULT 0"
+                )
+            }
+        }
+
         fun getInstance(context: Context): PodCaptureDatabase {
             return INSTANCE ?: synchronized(this) {
                 INSTANCE ?: buildDatabase(context).also { INSTANCE = it }
@@ -251,7 +260,7 @@ abstract class PodCaptureDatabase : RoomDatabase() {
                 PodCaptureDatabase::class.java,
                 DATABASE_NAME
             )
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10)
                 .build()
         }
     }

--- a/app/src/main/kotlin/com/podcapture/data/db/PodcastDao.kt
+++ b/app/src/main/kotlin/com/podcapture/data/db/PodcastDao.kt
@@ -132,6 +132,12 @@ interface PodcastDao {
     @Query("UPDATE episode_playback_history SET positionMs = :positionMs, lastPlayedAt = :lastPlayedAt WHERE episodeId = :episodeId")
     suspend fun updatePlaybackPosition(episodeId: Long, positionMs: Long, lastPlayedAt: Long = System.currentTimeMillis())
 
+    @Query("UPDATE episode_playback_history SET isFinished = 1, lastPlayedAt = :lastPlayedAt WHERE episodeId = :episodeId")
+    suspend fun markEpisodeFinished(episodeId: Long, lastPlayedAt: Long = System.currentTimeMillis())
+
+    @Query("SELECT * FROM episode_playback_history WHERE podcastId = :podcastId")
+    fun getPlaybackHistoryForPodcast(podcastId: Long): Flow<List<EpisodePlaybackHistory>>
+
     @Query("DELETE FROM episode_playback_history WHERE episodeId = :episodeId")
     suspend fun deletePlaybackHistory(episodeId: Long)
 

--- a/app/src/main/kotlin/com/podcapture/data/model/PlaybackHistory.kt
+++ b/app/src/main/kotlin/com/podcapture/data/model/PlaybackHistory.kt
@@ -35,7 +35,8 @@ data class EpisodePlaybackHistory(
     val positionMs: Long = 0,          // Last playback position
     val firstPlayedAt: Long = System.currentTimeMillis(),
     val lastPlayedAt: Long = System.currentTimeMillis(),
-    val localFilePath: String? = null  // If downloaded locally
+    val localFilePath: String? = null, // If downloaded locally
+    val isFinished: Boolean = false    // True when listened to the end
 )
 
 /**

--- a/app/src/main/kotlin/com/podcapture/data/repository/PodcastRepository.kt
+++ b/app/src/main/kotlin/com/podcapture/data/repository/PodcastRepository.kt
@@ -253,7 +253,8 @@ class PodcastRepository(
             positionMs = existing?.positionMs ?: 0,
             firstPlayedAt = existing?.firstPlayedAt ?: System.currentTimeMillis(),
             lastPlayedAt = System.currentTimeMillis(),
-            localFilePath = localFilePath ?: existing?.localFilePath
+            localFilePath = localFilePath ?: existing?.localFilePath,
+            isFinished = existing?.isFinished ?: false
         )
 
         podcastDao.insertPlaybackHistory(history)
@@ -261,6 +262,14 @@ class PodcastRepository(
 
     suspend fun updatePlaybackPosition(episodeId: Long, positionMs: Long) = withContext(Dispatchers.IO) {
         podcastDao.updatePlaybackPosition(episodeId, positionMs)
+    }
+
+    suspend fun markEpisodeFinished(episodeId: Long) = withContext(Dispatchers.IO) {
+        podcastDao.markEpisodeFinished(episodeId)
+    }
+
+    fun getPlaybackHistoryForPodcast(podcastId: Long): Flow<List<EpisodePlaybackHistory>> {
+        return podcastDao.getPlaybackHistoryForPodcast(podcastId)
     }
 
     suspend fun getPlaybackHistoryForEpisode(episodeId: Long): EpisodePlaybackHistory? {

--- a/app/src/main/kotlin/com/podcapture/ui/player/EpisodePlayerScreen.kt
+++ b/app/src/main/kotlin/com/podcapture/ui/player/EpisodePlayerScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.ExpandLess
@@ -191,6 +192,17 @@ fun EpisodePlayerScreen(
                     }
                 },
                 actions = {
+                    // Finished indicator
+                    if (uiState.isFinished) {
+                        Icon(
+                            imageVector = Icons.Filled.CheckCircle,
+                            contentDescription = "Episode finished",
+                            modifier = Modifier
+                                .padding(horizontal = 8.dp)
+                                .size(24.dp),
+                            tint = MaterialTheme.colorScheme.tertiary
+                        )
+                    }
                     // Captures count button
                     if (uiState.captures.isNotEmpty()) {
                         TextButton(onClick = { onNavigateToViewer(virtualAudioFileId, null) }) {

--- a/app/src/main/kotlin/com/podcapture/ui/player/EpisodePlayerViewModel.kt
+++ b/app/src/main/kotlin/com/podcapture/ui/player/EpisodePlayerViewModel.kt
@@ -42,7 +42,9 @@ data class EpisodePlayerUiState(
     val localFilePath: String? = null,  // For checking if episode is downloaded
     // Download state
     val downloadState: EpisodeDownloadState = EpisodeDownloadState.NotDownloaded,
-    val downloadProgress: Int = 0
+    val downloadProgress: Int = 0,
+    // Playback completion
+    val isFinished: Boolean = false
 )
 
 class EpisodePlayerViewModel(
@@ -59,6 +61,10 @@ class EpisodePlayerViewModel(
 
     private val _uiState = MutableStateFlow(EpisodePlayerUiState())
     val uiState: StateFlow<EpisodePlayerUiState> = _uiState.asStateFlow()
+
+    companion object {
+        private const val FINISH_THRESHOLD_MS = 30_000L
+    }
 
     init {
         loadEpisode()
@@ -119,9 +125,13 @@ class EpisodePlayerViewModel(
                     return@launch
                 }
 
-                // Get saved position and podcast title from history
+                // Get saved position and finished state from history
                 val history = podcastRepository.getPlaybackHistoryForEpisode(episodeId)
-                val resumePosition = history?.positionMs ?: 0L
+                val wasFinished = history?.isFinished ?: false
+                // Resume from saved position; restart from beginning if previously finished
+                val resumePosition = if (wasFinished) 0L else (history?.positionMs ?: 0L)
+
+                _uiState.value = _uiState.value.copy(isFinished = wasFinished)
 
                 // Record playback history
                 if (podcast != null) {
@@ -163,6 +173,16 @@ class EpisodePlayerViewModel(
         viewModelScope.launch {
             audioPlayerService.playbackState.collect { state ->
                 _uiState.value = _uiState.value.copy(playbackState = state)
+
+                // Detect completion: position within threshold of end while this episode is loaded
+                if (!_uiState.value.isFinished &&
+                    state.durationMs > 0 &&
+                    state.currentPositionMs >= state.durationMs - FINISH_THRESHOLD_MS &&
+                    audioPlayerService.currentAudioFileId.value == "episode_$episodeId"
+                ) {
+                    _uiState.value = _uiState.value.copy(isFinished = true)
+                    podcastRepository.markEpisodeFinished(episodeId)
+                }
             }
         }
     }
@@ -283,6 +303,11 @@ class EpisodePlayerViewModel(
             val position = audioPlayerService.getCurrentPosition()
             if (position > 0) {
                 podcastRepository.updatePlaybackPosition(episodeId, position)
+                val duration = audioPlayerService.getDuration()
+                if (!_uiState.value.isFinished && duration > 0 && position >= duration - FINISH_THRESHOLD_MS) {
+                    podcastRepository.markEpisodeFinished(episodeId)
+                    _uiState.value = _uiState.value.copy(isFinished = true)
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/podcapture/ui/search/PodcastDetailScreen.kt
+++ b/app/src/main/kotlin/com/podcapture/ui/search/PodcastDetailScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.DownloadDone
@@ -402,29 +403,41 @@ private fun EpisodeCard(
             Row(
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                // Episode/podcast artwork
+                // Episode/podcast artwork with finished overlay
                 val imageUrl = episode.imageUrl.ifEmpty { podcastArtworkUrl ?: "" }
-                if (imageUrl.isNotEmpty()) {
-                    AsyncImage(
-                        model = imageUrl,
-                        contentDescription = null,
-                        modifier = Modifier
-                            .size(60.dp)
-                            .clip(RoundedCornerShape(6.dp)),
-                        contentScale = ContentScale.Crop
-                    )
-                } else {
-                    Box(
-                        modifier = Modifier
-                            .size(60.dp)
-                            .clip(RoundedCornerShape(6.dp)),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Podcasts,
+                Box(modifier = Modifier.size(60.dp)) {
+                    if (imageUrl.isNotEmpty()) {
+                        AsyncImage(
+                            model = imageUrl,
                             contentDescription = null,
-                            modifier = Modifier.size(30.dp),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .clip(RoundedCornerShape(6.dp)),
+                            contentScale = ContentScale.Crop
+                        )
+                    } else {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .clip(RoundedCornerShape(6.dp)),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Podcasts,
+                                contentDescription = null,
+                                modifier = Modifier.size(30.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                    if (episodeItem.isFinished) {
+                        Icon(
+                            imageVector = Icons.Filled.CheckCircle,
+                            contentDescription = "Episode finished",
+                            modifier = Modifier
+                                .size(20.dp)
+                                .align(Alignment.BottomEnd),
+                            tint = MaterialTheme.colorScheme.tertiary
                         )
                     }
                 }

--- a/app/src/main/kotlin/com/podcapture/ui/search/PodcastDetailViewModel.kt
+++ b/app/src/main/kotlin/com/podcapture/ui/search/PodcastDetailViewModel.kt
@@ -23,7 +23,8 @@ data class EpisodeUiItem(
     val downloadState: EpisodeDownloadState = EpisodeDownloadState.NotDownloaded,
     val downloadProgress: Int = 0,
     val downloadedBytes: Long = 0L,
-    val totalBytes: Long = 0L
+    val totalBytes: Long = 0L,
+    val isFinished: Boolean = false
 )
 
 data class PodcastDetailUiState(
@@ -62,6 +63,7 @@ class PodcastDetailViewModel(
         observeBookmarkState()
         observeTags()
         observeDownloadStates()
+        observePlaybackHistory()
     }
 
     private fun loadPodcast() {
@@ -179,6 +181,26 @@ class PodcastDetailViewModel(
                             item.copy(downloadState = EpisodeDownloadState.NotDownloaded)
                         }
                     }
+                }
+
+                _uiState.value = _uiState.value.copy(
+                    episodes = updatedEpisodes,
+                    filteredEpisodes = updatedFiltered
+                )
+            }
+        }
+    }
+
+    private fun observePlaybackHistory() {
+        viewModelScope.launch {
+            podcastRepository.getPlaybackHistoryForPodcast(podcastId).collect { historyList ->
+                val finishedIds = historyList.filter { it.isFinished }.map { it.episodeId }.toSet()
+
+                val updatedEpisodes = _uiState.value.episodes.map { item ->
+                    item.copy(isFinished = item.episode.id in finishedIds)
+                }
+                val updatedFiltered = _uiState.value.filteredEpisodes?.map { item ->
+                    item.copy(isFinished = item.episode.id in finishedIds)
                 }
 
                 _uiState.value = _uiState.value.copy(


### PR DESCRIPTION
- Add isFinished field to EpisodePlaybackHistory (DB migration v9→v10)
- Resume from last position when reopening an episode; restart from beginning when episode was previously finished
- Mark episode finished when playback reaches within 30s of the end (detected both during playback and on screen dismiss)
- Show ✓ (CheckCircle) indicator in episode list card (artwork overlay) and in the player TopAppBar for finished episodes