### PR TITLE
Add private podcast import via RSS feed URL

### DIFF
--- a/app/src/main/kotlin/com/podcapture/data/repository/PodcastRepository.kt
+++ b/app/src/main/kotlin/com/podcapture/data/repository/PodcastRepository.kt
@@ -16,6 +16,7 @@ import com.podcapture.data.model.Tag
 import com.podcapture.data.model.toDomain
 import com.podcapture.data.opml.OpmlFeed
 import com.podcapture.data.opml.OpmlManager
+import com.podcapture.data.rss.RssFeedParser
 import com.podcapture.data.settings.SettingsDataStore
 import java.io.InputStream
 import java.io.OutputStream
@@ -432,6 +433,112 @@ class PodcastRepository(
         val audioFileId = "episode_$episodeId"
         val audioFile = audioFileDao.getFileById(audioFileId)
         audioFile != null
+    }
+
+    // ============ Private RSS Feed Import ============
+
+    private val rssFeedParser = RssFeedParser()
+
+    /**
+     * Imports a podcast from an RSS feed URL.
+     * First tries Podcast Index API lookup (works for public podcasts).
+     * Falls back to direct RSS parsing for private/unlisted podcasts.
+     * Returns a human-readable result message.
+     */
+    suspend fun importFromRssUrl(feedUrl: String): Result<String> = withContext(Dispatchers.IO) {
+        try {
+            val trimmedUrl = feedUrl.trim()
+
+            // Try Podcast Index API first (handles public podcasts with episode caching)
+            val apiResult = tryImportViaApi(trimmedUrl)
+            if (apiResult != null) return@withContext apiResult
+
+            // Fall back to direct RSS parsing for private/unlisted feeds
+            importViaRssParsing(trimmedUrl)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    private suspend fun tryImportViaApi(feedUrl: String): Result<String>? {
+        return try {
+            trackApiCall()
+            val response = api.getPodcastByFeedUrl(feedUrl)
+            if (response.status != "true" || response.feed == null) return null
+
+            val podcast = response.feed.toDomain()
+            val isBookmarked = podcastDao.isPodcastBookmarked(podcast.id).first()
+            if (isBookmarked) {
+                Result.success("\"${podcast.title}\" is already bookmarked")
+            } else {
+                bookmarkPodcast(podcast)
+                Result.success("\"${podcast.title}\" added to bookmarks")
+            }
+        } catch (_: Exception) {
+            null // API unavailable or feed not indexed — fall through to RSS parsing
+        }
+    }
+
+    private suspend fun importViaRssParsing(feedUrl: String): Result<String> {
+        return try {
+            val connection = URL(feedUrl).openConnection().apply {
+                connectTimeout = 15_000
+                readTimeout = 15_000
+                setRequestProperty("User-Agent", "PodCapture/1.0")
+                setRequestProperty("Accept", "application/rss+xml, application/xml, text/xml, */*")
+            }
+
+            val feed = connection.getInputStream().use { rssFeedParser.parse(it) }
+
+            if (feed.title.isEmpty()) {
+                return Result.failure(Exception("Could not read RSS feed — is the URL correct?"))
+            }
+
+            // Derive a stable negative ID from the feed URL (positive IDs belong to Podcast Index)
+            val podcastId = feedUrl.fold(0L) { acc, c -> acc * 31L + c.code }
+                .let { h -> if (h >= 0) -(h + 1) else h }
+
+            val isBookmarked = podcastDao.isPodcastBookmarked(podcastId).first()
+            if (isBookmarked) {
+                return Result.success("\"${feed.title}\" is already bookmarked")
+            }
+
+            val bookmarked = BookmarkedPodcast(
+                id = podcastId,
+                title = feed.title,
+                author = feed.author.ifEmpty { "Unknown" },
+                description = feed.description,
+                artworkUrl = feed.imageUrl,
+                feedUrl = feedUrl,
+                language = feed.language.ifEmpty { "en" },
+                episodeCount = feed.episodes.size,
+                lastUpdateTime = System.currentTimeMillis() / 1000
+            )
+
+            val cachedEpisodes = feed.episodes.map { ep ->
+                val epId = "$podcastId:${ep.guid}".fold(0L) { acc, c -> acc * 31L + c.code }
+                    .let { h -> if (h >= 0) -(h + 1) else h }
+                CachedEpisode(
+                    id = epId,
+                    podcastId = podcastId,
+                    title = ep.title,
+                    description = ep.description,
+                    link = ep.link,
+                    publishedDate = ep.publishedDate,
+                    duration = ep.duration,
+                    audioUrl = ep.audioUrl,
+                    audioType = ep.audioType,
+                    audioSize = ep.audioSize,
+                    imageUrl = ep.imageUrl
+                )
+            }
+
+            podcastDao.bookmarkPodcastWithEpisodes(bookmarked, cachedEpisodes)
+
+            Result.success("\"${feed.title}\" added to bookmarks")
+        } catch (e: Exception) {
+            Result.failure(Exception("Failed to load RSS feed: ${e.message}"))
+        }
     }
 
     // ============ OPML Import/Export ============

--- a/app/src/main/kotlin/com/podcapture/data/rss/RssFeedParser.kt
+++ b/app/src/main/kotlin/com/podcapture/data/rss/RssFeedParser.kt
@@ -1,0 +1,216 @@
+package com.podcapture.data.rss
+
+import android.util.Xml
+import org.xmlpull.v1.XmlPullParser
+import java.io.InputStream
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+class RssFeedParser {
+
+    data class ParsedFeed(
+        val title: String,
+        val author: String,
+        val description: String,
+        val imageUrl: String,
+        val language: String,
+        val episodes: List<ParsedEpisode>
+    )
+
+    data class ParsedEpisode(
+        val guid: String,
+        val title: String,
+        val description: String,
+        val audioUrl: String,
+        val audioType: String,
+        val audioSize: Long,
+        val publishedDate: Long,
+        val duration: Int,
+        val imageUrl: String,
+        val link: String?
+    )
+
+    fun parse(inputStream: InputStream): ParsedFeed {
+        val parser = Xml.newPullParser()
+        parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, false)
+        parser.setInput(inputStream, null)
+
+        var feedTitle = ""
+        var feedAuthor = ""
+        var feedDescription = ""
+        var feedImageUrl = ""
+        var feedLanguage = "en"
+        val episodes = mutableListOf<ParsedEpisode>()
+
+        var inChannel = false
+        var inItem = false
+        var inImage = false
+
+        var itemTitle = ""
+        var itemGuid = ""
+        var itemDescription = ""
+        var itemAudioUrl = ""
+        var itemAudioType = "audio/mpeg"
+        var itemAudioSize = 0L
+        var itemPubDate = ""
+        var itemDuration = ""
+        var itemImageUrl = ""
+        var itemLink = ""
+
+        var eventType = parser.eventType
+
+        while (eventType != XmlPullParser.END_DOCUMENT) {
+            when (eventType) {
+                XmlPullParser.START_TAG -> when (parser.name) {
+                    "channel" -> inChannel = true
+                    "item" -> {
+                        inItem = true
+                        itemTitle = ""; itemGuid = ""; itemDescription = ""
+                        itemAudioUrl = ""; itemAudioType = "audio/mpeg"; itemAudioSize = 0L
+                        itemPubDate = ""; itemDuration = ""; itemImageUrl = ""; itemLink = ""
+                    }
+                    "image" -> if (inChannel && !inItem) inImage = true
+                    "enclosure" -> if (inItem) {
+                        itemAudioUrl = parser.getAttributeValue(null, "url") ?: ""
+                        itemAudioType = parser.getAttributeValue(null, "type") ?: "audio/mpeg"
+                        itemAudioSize = parser.getAttributeValue(null, "length")?.toLongOrNull() ?: 0L
+                    }
+                    "itunes:image" -> {
+                        val href = parser.getAttributeValue(null, "href") ?: ""
+                        if (href.isNotEmpty()) {
+                            if (inItem) itemImageUrl = href
+                            else if (inChannel && feedImageUrl.isEmpty()) feedImageUrl = href
+                        }
+                    }
+                    "title" -> {
+                        val text = readText(parser)
+                        when {
+                            inItem -> itemTitle = text
+                            inImage -> { /* skip image block title */ }
+                            inChannel -> feedTitle = text
+                        }
+                    }
+                    "description", "itunes:subtitle" -> {
+                        val text = readText(parser)
+                        when {
+                            inItem -> if (itemDescription.isEmpty()) itemDescription = text
+                            inChannel -> if (feedDescription.isEmpty()) feedDescription = text
+                        }
+                    }
+                    "itunes:summary", "content:encoded" -> {
+                        val text = readText(parser)
+                        when {
+                            inItem -> if (itemDescription.isEmpty()) itemDescription = text
+                            inChannel -> if (feedDescription.isEmpty()) feedDescription = text
+                        }
+                    }
+                    "itunes:author", "author", "managingEditor" -> {
+                        val text = readText(parser)
+                        if (inChannel && !inItem && feedAuthor.isEmpty()) feedAuthor = text
+                    }
+                    "language" -> {
+                        val text = readText(parser)
+                        if (inChannel && !inItem) feedLanguage = text
+                    }
+                    "pubDate", "dc:date" -> {
+                        val text = readText(parser)
+                        if (inItem) itemPubDate = text
+                    }
+                    "itunes:duration" -> {
+                        val text = readText(parser)
+                        if (inItem) itemDuration = text
+                    }
+                    "guid" -> {
+                        val text = readText(parser)
+                        if (inItem) itemGuid = text
+                    }
+                    "link" -> {
+                        val text = readText(parser)
+                        if (inItem) itemLink = text
+                    }
+                    "url" -> {
+                        val text = readText(parser)
+                        if (inImage && feedImageUrl.isEmpty()) feedImageUrl = text
+                    }
+                }
+                XmlPullParser.END_TAG -> when (parser.name) {
+                    "item" -> {
+                        if (itemAudioUrl.isNotEmpty()) {
+                            episodes.add(
+                                ParsedEpisode(
+                                    guid = itemGuid.ifEmpty { itemAudioUrl },
+                                    title = itemTitle,
+                                    description = itemDescription,
+                                    audioUrl = itemAudioUrl,
+                                    audioType = itemAudioType,
+                                    audioSize = itemAudioSize,
+                                    publishedDate = parsePubDate(itemPubDate),
+                                    duration = parseDuration(itemDuration),
+                                    imageUrl = itemImageUrl,
+                                    link = itemLink.ifEmpty { null }
+                                )
+                            )
+                        }
+                        inItem = false
+                    }
+                    "image" -> inImage = false
+                    "channel" -> inChannel = false
+                }
+            }
+            eventType = parser.next()
+        }
+
+        return ParsedFeed(
+            title = feedTitle,
+            author = feedAuthor,
+            description = feedDescription,
+            imageUrl = feedImageUrl,
+            language = feedLanguage,
+            episodes = episodes
+        )
+    }
+
+    private fun readText(parser: XmlPullParser): String {
+        val sb = StringBuilder()
+        var next = parser.next()
+        while (next == XmlPullParser.TEXT || next == XmlPullParser.CDSECT) {
+            sb.append(parser.text ?: "")
+            next = parser.next()
+        }
+        // Parser is now at END_TAG (or next START_TAG for mixed content)
+        return sb.toString().trim()
+    }
+
+    private fun parsePubDate(pubDate: String): Long {
+        if (pubDate.isEmpty()) return System.currentTimeMillis() / 1000
+        val formats = listOf(
+            "EEE, dd MMM yyyy HH:mm:ss zzz",
+            "EEE, dd MMM yyyy HH:mm:ss Z",
+            "EEE, dd MMM yyyy HH:mm zzz",
+            "dd MMM yyyy HH:mm:ss zzz",
+            "yyyy-MM-dd'T'HH:mm:ssXXX",
+            "yyyy-MM-dd'T'HH:mm:ss'Z'"
+        )
+        for (format in formats) {
+            try {
+                val date = SimpleDateFormat(format, Locale.ENGLISH).parse(pubDate)
+                if (date != null) return date.time / 1000
+            } catch (_: Exception) { }
+        }
+        return System.currentTimeMillis() / 1000
+    }
+
+    private fun parseDuration(duration: String): Int {
+        if (duration.isEmpty()) return 0
+        val parts = duration.trim().split(":")
+        return when (parts.size) {
+            3 -> (parts[0].toIntOrNull() ?: 0) * 3600 +
+                 (parts[1].toIntOrNull() ?: 0) * 60 +
+                 (parts[2].toIntOrNull() ?: 0)
+            2 -> (parts[0].toIntOrNull() ?: 0) * 60 +
+                 (parts[1].toIntOrNull() ?: 0)
+            1 -> duration.trim().toIntOrNull() ?: 0
+            else -> 0
+        }
+    }
+}

--- a/app/src/main/kotlin/com/podcapture/ui/search/PodcastSearchScreen.kt
+++ b/app/src/main/kotlin/com/podcapture/ui/search/PodcastSearchScreen.kt
@@ -21,8 +21,10 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Podcasts
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -35,6 +37,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -46,6 +49,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -76,6 +80,16 @@ fun PodcastSearchScreen(
         }
     }
 
+    if (uiState.showRssDialog) {
+        RssFeedDialog(
+            url = uiState.rssUrl,
+            isLoading = uiState.isImportingRss,
+            onUrlChanged = viewModel::onRssUrlChanged,
+            onConfirm = viewModel::onImportRssUrl,
+            onDismiss = viewModel::onDismissRssDialog
+        )
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -95,6 +109,25 @@ fun PodcastSearchScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
+            // + button above search field
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TextButton(onClick = viewModel::onShowRssDialog) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    Text("Add private podcast")
+                }
+            }
+
             // Search bar
             OutlinedTextField(
                 value = uiState.query,
@@ -450,4 +483,67 @@ private fun formatDuration(durationSeconds: Int): String {
     } else {
         "${minutes}m"
     }
+}
+
+@Composable
+private fun RssFeedDialog(
+    url: String,
+    isLoading: Boolean,
+    onUrlChanged: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add Private Podcast") },
+        text = {
+            Column {
+                Text(
+                    text = "Enter the RSS feed URL of your private podcast.",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Spacer(Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = url,
+                    onValueChange = onUrlChanged,
+                    modifier = Modifier.fillMaxWidth(),
+                    placeholder = { Text("https://example.com/feed.rss") },
+                    singleLine = true,
+                    enabled = !isLoading,
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Uri,
+                        imeAction = ImeAction.Done
+                    ),
+                    keyboardActions = KeyboardActions(onDone = { onConfirm() })
+                )
+                if (isLoading) {
+                    Spacer(Modifier.height(12.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                        Text(
+                            text = "Loading feed…",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = onConfirm,
+                enabled = url.isNotBlank() && !isLoading
+            ) {
+                Text("Import")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !isLoading) {
+                Text("Cancel")
+            }
+        }
+    )
 }

--- a/app/src/main/kotlin/com/podcapture/ui/search/PodcastSearchViewModel.kt
+++ b/app/src/main/kotlin/com/podcapture/ui/search/PodcastSearchViewModel.kt
@@ -20,7 +20,10 @@ data class PodcastSearchUiState(
     val error: String? = null,
     val hasSearched: Boolean = false,
     val latestEpisodes: List<LatestEpisode> = emptyList(),
-    val isLoadingLatestEpisodes: Boolean = false
+    val isLoadingLatestEpisodes: Boolean = false,
+    val showRssDialog: Boolean = false,
+    val rssUrl: String = "",
+    val isImportingRss: Boolean = false
 )
 
 class PodcastSearchViewModel(
@@ -104,5 +107,46 @@ class PodcastSearchViewModel(
 
     fun onErrorDismissed() {
         _uiState.value = _uiState.value.copy(error = null)
+    }
+
+    fun onShowRssDialog() {
+        _uiState.value = _uiState.value.copy(showRssDialog = true, rssUrl = "", isImportingRss = false)
+    }
+
+    fun onDismissRssDialog() {
+        if (!_uiState.value.isImportingRss) {
+            _uiState.value = _uiState.value.copy(showRssDialog = false, rssUrl = "")
+        }
+    }
+
+    fun onRssUrlChanged(url: String) {
+        _uiState.value = _uiState.value.copy(rssUrl = url)
+    }
+
+    fun onImportRssUrl() {
+        val url = _uiState.value.rssUrl.trim()
+        if (url.isBlank()) return
+
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isImportingRss = true)
+
+            podcastRepository.importFromRssUrl(url).fold(
+                onSuccess = { message ->
+                    _uiState.value = _uiState.value.copy(
+                        isImportingRss = false,
+                        showRssDialog = false,
+                        rssUrl = "",
+                        error = message
+                    )
+                    loadLatestEpisodes()
+                },
+                onFailure = { error ->
+                    _uiState.value = _uiState.value.copy(
+                        isImportingRss = false,
+                        error = error.message ?: "Failed to import RSS feed"
+                    )
+                }
+            )
+        }
     }
 }


### PR DESCRIPTION
- Add RssFeedParser to parse RSS/Atom XML directly (title, author, artwork, episodes)
- Add importFromRssUrl() to PodcastRepository: tries Podcast Index API first for public podcasts, falls back to direct RSS parsing for private/unlisted feeds; generates a stable negative ID from the feed URL to distinguish from Podcast Index IDs
- Add RSS dialog state (showRssDialog, rssUrl, isImportingRss) and onShowRssDialog / onDismissRssDialog / onRssUrlChanged / onImportRssUrl to PodcastSearchViewModel
- Add "Add private podcast" TextButton above the search field in PodcastSearchScreen and an AlertDialog with URL input; success/error shown via snackbar

Imported podcasts are bookmarked to Room and appear on the home screen.